### PR TITLE
Enables Repo-specific `force_delete` Config

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,7 +1,7 @@
 # The version of the configuration file format
 version: 1
 # Your module version - must be changed to release a new version
-module_version: 0.1.0
+module_version: 1.0.0
 
 tests: []
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,20 +1,20 @@
 output "registry_id" {
-  value       = local.repository_creation_enabled ? aws_ecr_repository.name[local.image_names[0]].registry_id : ""
+  value       = local.repository_creation_enabled ? aws_ecr_repository.name[keys(local.image_names)[0]].registry_id : ""
   description = "Registry ID"
 }
 
 output "repository_name" {
-  value       = local.repository_creation_enabled ? aws_ecr_repository.name[local.image_names[0]].name : ""
+  value       = local.repository_creation_enabled ? aws_ecr_repository.name[keys(local.image_names)[0]].name : ""
   description = "Name of first repository created"
 }
 
 output "repository_url" {
-  value       = local.repository_creation_enabled ? aws_ecr_repository.name[local.image_names[0]].repository_url : ""
+  value       = local.repository_creation_enabled ? aws_ecr_repository.name[keys(local.image_names)[0]].repository_url : ""
   description = "URL of first repository created"
 }
 
 output "repository_arn" {
-  value       = local.repository_creation_enabled ? aws_ecr_repository.name[local.image_names[0]].arn : ""
+  value       = local.repository_creation_enabled ? aws_ecr_repository.name[keys(local.image_names)[0]].arn : ""
   description = "ARN of first repository created"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -41,9 +41,11 @@ variable "max_image_count" {
 }
 
 variable "image_names" {
-  type        = list(string)
-  default     = []
-  description = "List of Docker local image names, used as repository names for AWS ECR "
+  type        = map(object({
+    force_delete_override = optional(bool,false)
+    archive_enabled = optional(bool,false)
+  }))
+  description = "Map of Docker local image names, used as repository names for AWS ECR. Sets `force_delete` option"
 }
 
 variable "image_tag_mutability" {
@@ -71,12 +73,6 @@ variable "encryption_configuration" {
   })
   description = "ECR encryption configuration"
   default     = null
-}
-
-variable "force_delete" {
-  type        = bool
-  description = "Whether to delete the repository even if it contains images"
-  default     = false
 }
 
 variable "replication_regions" {

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.0"
+  required_version = ">= 1.3.0"
 
   required_providers {
     aws = {


### PR DESCRIPTION
⚠️ Breaking Changes ⚠️ 
## what

- major release 1.0.0
- converts var.image_names from list to map(object())
  - - adds `force_delete` and `archive_enabled` attributes
- **removes** `var.force_delete`
- adds `module-tests` configuration to perform validation
- adds `local.lifecycle_policy_archive` which sets rules to delete images except tagged releases



## why

- previously `var.force_delete` was set globally across all repos
- setting this per repo allows us to choose repos that should be force deleted, when retiring a service
- allows `archive_enabled` to be set per repo
  - this applies ecr_lifecycle_policy rules which will delete all images from the repo, except those tagged as a release (e.g. `x.x.x`)
- additional TF variables can be added to `module-tests/ecr-sandbox.tf` and set on `spacelift/config.yml`

## references
- https://github.com/BrightDotAi/infrastructure/pull/1488
