### PR TITLE
feat: support pull through ECR repos

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,7 +1,7 @@
 # The version of the configuration file format
 version: 1
 # Your module version - must be changed to release a new version
-module_version: 1.0.0
+module_version: 1.1.0
 
 tests: []
 

--- a/main.tf
+++ b/main.tf
@@ -12,7 +12,7 @@ locals {
   repository_creation_enabled = module.this.enabled && var.repository_creation_enabled
 
   principals_pullthrough_access = toset(concat(var.principals_readonly_access, var.principals_full_access, var.principals_lambda))
-  image_names_pullthrough       = toset([ for k,v in local.image_names : k if contains(var.pulltrhough_prefixes, split("/", k)[0]) ])
+  image_names_pullthrough       = toset([ for k,v in local.image_names : k if contains(var.pullthrough_prefixes, split("/", k)[0]) ])
 }
 
 resource "aws_ecr_repository" "name" {

--- a/main.tf
+++ b/main.tf
@@ -7,9 +7,12 @@
 }
 
 locals {
-  _name       = var.use_fullname ? module.this.id : module.this.name
-  image_names = length(var.image_names) > 0 ? var.image_names : tomap(local._name)
+  _name                       = var.use_fullname ? module.this.id : module.this.name
+  image_names                 = length(var.image_names) > 0 ? var.image_names : tomap(local._name)
   repository_creation_enabled = module.this.enabled && var.repository_creation_enabled
+
+  principals_pullthrough_access = toset(concat(var.principals_readonly_access, var.principals_full_access, var.principals_lambda))
+  image_names_pullthrough       = toset([ for k,v in local.image_names : k if contains(var.pulltrhough_prefixes, split("/", k)[0]) ])
 }
 
 resource "aws_ecr_repository" "name" {
@@ -196,6 +199,25 @@ data "aws_iam_policy_document" "resource_full_access" {
   }
 }
 
+ data "aws_iam_policy_document" "resource_pull_through_cache" {
+   count = module.this.enabled ? 1 : 0
+
+   statement {
+     sid    = "PullThroughAccess"
+     effect = "Allow"
+
+     principals {
+       type        = "AWS"
+       identifiers = local.principals_pullthrough_access
+     }
+
+     actions = [
+       "ecr:BatchImportUpstreamImage",
+       "ecr:TagResource"
+     ]
+   }
+ }
+
 data "aws_iam_policy_document" "lambda_access" {
   count = module.this.enabled && length(var.principals_lambda) > 0 ? 1 : 0
 
@@ -244,11 +266,27 @@ data "aws_iam_policy_document" "resource" {
   ])
 }
 
+ data "aws_iam_policy_document" "pullthrough_resource" {
+   count                   = module.this.enabled ? 1 : 0
+   source_policy_documents = [data.aws_iam_policy_document.resource_pull_through_cache[0].json]
+   override_policy_documents = distinct([
+       local.principals_readonly_access_non_empty ? data.aws_iam_policy_document.resource_readonly_access[0].json : data.aws_iam_policy_document.empty[0].json,
+       local.principals_full_access_non_empty ? data.aws_iam_policy_document.resource_full_access[0].json : data.aws_iam_policy_document.empty[0].json,
+       local.principals_lambda_non_empty ? data.aws_iam_policy_document.lambda_access[0].json : data.aws_iam_policy_document.empty[0].json,
+   ])
+ }
+
 resource "aws_ecr_repository_policy" "name" {
-  for_each   = local.ecr_need_policy && module.this.enabled ? local.image_names : {}
+  for_each   = local.ecr_need_policy && module.this.enabled ? setsubtract(keys(local.image_names), local.image_names_pullthrough) : toset([])
   repository = each.key
   policy     = join("", data.aws_iam_policy_document.resource[*].json)
 }
+
+ resource "aws_ecr_repository_policy" "pullthrough" {
+   for_each   = local.ecr_need_policy && module.this.enabled ? local.image_names_pullthrough : toset([])
+   repository = each.key
+   policy = join("", data.aws_iam_policy_document.pullthrough_resource[*].json)
+ }
 
 data "aws_caller_identity" "current" {}
 

--- a/variables.tf
+++ b/variables.tf
@@ -87,7 +87,7 @@ variable "repository_creation_enabled" {
   default     = true
 }
 
-variable "pulltrhough_prefixes" {
+variable "pullthrough_prefixes" {
   type = list(string)
   default = []
 }

--- a/variables.tf
+++ b/variables.tf
@@ -86,3 +86,8 @@ variable "repository_creation_enabled" {
   description = "Whether ECR repositories should be created"
   default     = true
 }
+
+variable "pulltrhough_prefixes" {
+  type = list(string)
+  default = []
+}


### PR DESCRIPTION
## what

- add support to create repos that will work are upstream pull through mirrors, via the `pullthrough_prefixes` variable.

## why

- any repo that has a prefix that matches the a value in `pullthrough_prefixes` will be created with a policy that will enable read access and pull through permissions to principals that have read access, i.e. lambda, read only and full access. This is needed to support pull through cache rules that are to be configured externally.

## references


