### PR TITLE
fix: repository policies when creation is disabled

### DIFF
--- a/.spacelift/config.yml
+++ b/.spacelift/config.yml
@@ -1,7 +1,7 @@
 # The version of the configuration file format
 version: 1
 # Your module version - must be changed to release a new version
-module_version: 1.1.0
+module_version: 1.1.1
 
 tests: []
 

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
  locals {
-   enabled       = local.enabled
+   enabled       = module.this.enabled
    enabled_count = local.enabled ? 1 : 0
    
   principals_readonly_access_non_empty = length(var.principals_readonly_access) > 0


### PR DESCRIPTION
## what

- only apply ECR policies to existing repositories when repository creation is disabled.

## why

- disabling repository creation expects repositories to already exist. This is used in conjunction with repository replication, where the repository is created when data is pushed in another region. If data is never pushed, the repository is not created yet we still try to attach a policy which leads to an error.

## references


